### PR TITLE
Pass through alpha value to dimming view

### DIFF
--- a/Jelly/Classes/JellyPresentationController.swift
+++ b/Jelly/Classes/JellyPresentationController.swift
@@ -29,8 +29,8 @@ class JellyPresentationController : UIPresentationController {
             case .blur(let effectStyle):
                 self.setupBlurView()
                 animateBlurView(effectStyle: effectStyle)
-            case .dimmed(_):
-                self.setupDimmingView()
+            case .dimmed(let alpha):
+                self.setupDimmingView(withAlpha: alpha)
                 animateDimmingView()
         }
     }


### PR DESCRIPTION
It seems like this alpha value on the enum was supposed to be passed through to the dimming view, otherwise the dimming view is stuck at 0.5 alpha.