### PR TITLE
iOS 13 Support

### DIFF
--- a/Jelly/Classes/private/Animators/Animated Animators/CoverAnimator.swift
+++ b/Jelly/Classes/private/Animators/Animated Animators/CoverAnimator.swift
@@ -3,6 +3,7 @@ import Foundation
 final class CoverAnimator: NSObject {
     private let presentationType : PresentationType
     private let presentation : CoverPresentation
+    private var currentPropertyAnimator: UIViewPropertyAnimator?
     
     init(presentationType: PresentationType, presentation: CoverPresentation) {
         self.presentationType = presentationType
@@ -14,11 +15,15 @@ final class CoverAnimator: NSObject {
 extension CoverAnimator : UIViewControllerAnimatedTransitioning {
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let propertyAnimator = createPropertyAnimator(using: transitionContext)
+        currentPropertyAnimator = propertyAnimator
         propertyAnimator.startAnimation()
     }
     
     func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
-        return createPropertyAnimator(using: transitionContext)
+        // According to Apple's document:
+        // "You must return the same animator object for the duration of the transition."
+        // https://developer.apple.com/documentation/uikit/uiviewcontrolleranimatedtransitioning/1829434-interruptibleanimator
+        return currentPropertyAnimator ?? createPropertyAnimator(using: transitionContext)
     }
     
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {

--- a/Jelly/Classes/private/Animators/Animated Animators/FadeAnimator.swift
+++ b/Jelly/Classes/private/Animators/Animated Animators/FadeAnimator.swift
@@ -3,6 +3,7 @@ import Foundation
 final class FadeAnimator: NSObject {
     private let presentationType : PresentationType
     private let presentation : FadePresentation
+    private var currentPropertyAnimator: UIViewPropertyAnimator?
 
     init(presentationType: PresentationType, presentation: FadePresentation) {
         self.presentationType = presentationType
@@ -13,7 +14,7 @@ final class FadeAnimator: NSObject {
 
 extension FadeAnimator : UIViewControllerAnimatedTransitioning {
     func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
-        return createPropertyAnimator(using: transitionContext)
+        return currentPropertyAnimator ?? createPropertyAnimator(using: transitionContext)
     }
     
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
@@ -22,6 +23,7 @@ extension FadeAnimator : UIViewControllerAnimatedTransitioning {
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let propertyAnimator = createPropertyAnimator(using: transitionContext)
+        currentPropertyAnimator = propertyAnimator
         propertyAnimator.startAnimation()
     }
     

--- a/Jelly/Classes/private/Animators/Animated Animators/SlideAnimator.swift
+++ b/Jelly/Classes/private/Animators/Animated Animators/SlideAnimator.swift
@@ -3,6 +3,7 @@ import Foundation
 final class SlideAnimator: NSObject {
     private let presentationType : PresentationType
     private let presentation : SlidePresentation
+    private var currentPropertyAnimator: UIViewPropertyAnimator?
 
     init(presentationType: PresentationType, presentation: SlidePresentation) {
         self.presentationType = presentationType
@@ -18,11 +19,12 @@ extension SlideAnimator : UIViewControllerAnimatedTransitioning {
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let propertyAnimator = createPropertyAnimator(using: transitionContext)
+        currentPropertyAnimator = propertyAnimator
         propertyAnimator.startAnimation()
     }
     
     func interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewImplicitlyAnimating {
-        return createPropertyAnimator(using: transitionContext)
+        return currentPropertyAnimator ?? createPropertyAnimator(using: transitionContext)
     }
     
     func createPropertyAnimator(using transitionContext: UIViewControllerContextTransitioning) -> UIViewPropertyAnimator{

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Jelly-Animators: Elegant Viewcontroller Animations in Swift](https://github.com/SebastianBoldt/Jelly/blob/master/Github/Jellyfish.png?raw=true)
 
 <a href="https://paypal.me/boldtsebastian"><img src="https://img.shields.io/badge/paypal-donate-blue.svg?longCache=true&style=flat-square" alt="current version" /></a>
-<a href="https://cocoapods.org/pods/Jelly"><img src="https://img.shields.io/badge/version-2.2.0-green.svg?longCache=true&style=flat-square" alt="current version" /></a>
+<a href="https://cocoapods.org/pods/Jelly"><img src="https://img.shields.io/badge/version-2.2.1-green.svg?longCache=true&style=flat-square" alt="current version" /></a>
 <a href="http://twitter.com/sebastianboldt"><img src="https://img.shields.io/badge/twitter-@sebastianboldt-blue.svg?longCache=true&style=flat-square" alt="twitter handle" /></a>
 <a href="https://developer.apple.com/swift"><img src="https://img.shields.io/badge/swift5.0-compatible-orange.svg?longCache=true&style=flat-square" alt="Swift 4.2 compatible" /></a>
 <a href="https://www.apple.com/de/ios/ios-12/"><img src="https://img.shields.io/badge/platform-iOS-lightgray.svg?longCache=true&style=flat-square" alt="platform" /></a>


### PR DESCRIPTION
Hi, 
I have tried to use Jelly on iOS 13 beta, And I found almost every type of transition doesn't seemed to meet expectations (And I also found an issue here later: https://github.com/SebastianBoldt/Jelly/issues/70).

I think the major reason here is Jelly will create and return a new property animator every time UIViewControllerAnimatedTransitioning's `interruptibleAnimator(using transitionContext: UIViewControllerContextTransitioning)` method been called. But according to Apple's document (https://developer.apple.com/documentation/uikit/uiviewcontrolleranimatedtransitioning/1829434-interruptibleanimator), We should return the same animator object for the duration of the transition. But I don't know why it still looks well on iOS 12 and earlier versions even if you don't return the same animator in this method.

I have tested my code on both iOS 13 beta 5 simulator and iPhone. Every type of transition in the demo app works well just like them before.

And thank you for bringing such a great transition animation library to us.

Roc