### PR TITLE
Fixed missing Swift version

### DIFF
--- a/Jelly.podspec
+++ b/Jelly.podspec
@@ -24,5 +24,6 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = '10.0'
     s.source_files = 'Jelly/Classes/**/*'
     s.frameworks = 'UIKit'
+    s.swift_version = '4.2'
 end
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Jelly is available through [CocoaPods](http://cocoapods.org). To install
 it, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Jelly', '~> 2.0'
+pod 'Jelly', '~> 2.2.2'
 ```
 
 <img src="https://github.com/SebastianBoldt/Jelly/blob/master/Github/mentions.png?raw=true" width="400">


### PR DESCRIPTION
Hello, I've added Swift version to podspec which fixes error during pod installation.

```
[!] Unable to determine Swift version for the following pods:

- `Jelly-library` does not specify a Swift version and none of the targets (`Pods`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```