### PR TITLE
Fix: updateHeight of Animator does not work as expected

### DIFF
--- a/Jelly/Classes/public/Animator.swift
+++ b/Jelly/Classes/public/Animator.swift
@@ -155,11 +155,11 @@ extension Animator: LiveUpdatable {
         }
 
         if var presentation = presentation as? FadePresentation {
-            presentation.presentationSize = PresentationSize(width: presentation.presentationSize.height, height: height)
+            presentation.presentationSize = PresentationSize(width: presentation.presentationSize.width, height: height)
             self.presentation = presentation
             currentPresentationController.updatePresentation(presentation: presentation, duration: duration)
         } else if var presentation = presentation as? CoverPresentation {
-            presentation.presentationSize = PresentationSize(width: presentation.presentationSize.height, height: height)
+            presentation.presentationSize = PresentationSize(width: presentation.presentationSize.width, height: height)
             self.presentation = presentation
             currentPresentationController.updatePresentation(presentation: presentation, duration: duration)
         }


### PR DESCRIPTION
#### Summary

I have a scenario that have to update the height of presented view controller. 
But `Animator.updateHeight(height:duration:)` does NOT work as expected, the width of presented view controller will be modified after calling this API.

The root cause is the height of original presentation-size was applied to the width by mistake.

And the workaround is using `updateSize(presentationSize:duration)` instead.